### PR TITLE
Update config.rb to require fileutils

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH.unshift(File.expand_path('../vendor/bundle', __FILE__))
 require 'bundler/setup'
 
+require 'fileutils'
 require 'alphred'
 
 module Forecast


### PR DESCRIPTION
Without fileutils, I get the following error when trying to set an API key with config-forecast:

```
[ERROR: alfred.workflow.output.script] /Users/kj/Dropbox/Alfred/Alfred.alfredpreferences/workflows/user.workflow.AA22CE0C-25A1-44E5-B3E8-263CAB430CD4/vendor/bundle/ruby/2.0.0/gems/alphred-1.2.1/lib/alphred/config.rb:24:in `update!': 
uninitialized constant Alphred::Config::FileUtils (NameError)
	from -e:1:in `<main>'
```

Requiring fileutils in config.rb fixes this.